### PR TITLE
refactor(ci): use codecov instead of CodeCoverageSummary

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -77,17 +77,5 @@ jobs:
       - name: generate coverage xml
         run: .tox/py3/bin/coverage xml -o coverage.xml
 
-      - name: Generate Code Coverage Summary Report.
-        uses: irongut/CodeCoverageSummary@v1.2.0
-        with:
-          filename: coverage.xml
-          fail_below_min: false
-          format: markdown
-          output: both # output to console and file
-
-      - name: Add Coverage Report as Sticky PR Comment.
-        uses: marocchino/sticky-pull-request-comment@v2
-        if: github.event_name == 'pull_request'
-        with:
-          recreate: true
-          path: code-coverage-results.md
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v3

--- a/DEVELOPMENT.adoc
+++ b/DEVELOPMENT.adoc
@@ -25,6 +25,8 @@ $ python3 -m pip install -r requirements-dev.txt
 
 [[testing]]
 === 🧪 Testing
+https://codecov.io/gh/JonasPammer/cookiecutter-pypackage-test[image:https://codecov.io/gh/JonasPammer/cookiecutter-pypackage-test/branch/master/graph/badge.svg[codecov code coverage on master]]
+
 Automatic Tests are run on each Contribution using GitHub Workflows.
 
 To run the tests yourself, simply run `tox` on the command line.


### PR DESCRIPTION
I really do not know why I chose this CodeCoverageSummary thing.

## **Required Checklist**

- [ ] Documentation has been altered or extended appropriately
- [x] This pull request and its commits address only a single concern
- [x] I am a nice guy <!-- the 'too long; did not read;' of the CODE_OF_CONDUCT.md -->

## Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)

## _Optional_ Checklist

- [x] pre-commit was installed in local development environment (if not, a GitHub workflow will run pre-commit once you create the request)

- [x] my commits are small, single-purpose, detailed and maybe even follow the [conventional commit specification](https://github.com/JonasPammer/JonasPammer/blob/master/demystifying/conventional_commits.adoc) for extra convenience of the reviewer
