### PR TITLE
ci: create scorecard workflow as per official template

### DIFF
--- a/.github/workflows/scorecards.yml
+++ b/.github/workflows/scorecards.yml
@@ -1,0 +1,63 @@
+name: OSSF Scorecards supply-chain security
+"on":
+  # Only the default branch is supported.
+  branch_protection_rule:
+  schedule:
+    # At 11:22 on Monday.
+    - cron: "22 11 * * 1"
+  push:
+    branches: ["master"]
+
+# Declare default permissions as read only.
+permissions: read-all
+
+jobs:
+  analysis:
+    name: Scorecards analysis
+    runs-on: ubuntu-latest
+    permissions:
+      # Needed to upload the results to code-scanning dashboard.
+      security-events: write
+      # Used to receive a badge. (Upcoming feature)
+      id-token: write
+      # Needs for private repositories.
+      contents: read
+      actions: read
+
+    steps:
+      - name: "Checkout code"
+        uses: actions/checkout@a12a3943b4bdde767164f792f33f40b04645d846 # v3.0.0
+        with:
+          persist-credentials: false
+
+      - name: "Run analysis"
+        uses: ossf/scorecard-action@3e15ea8318eee9b333819ec77a36aca8d39df13e # v1.1.1
+        with:
+          results_file: results.sarif
+          results_format: sarif
+          # (Optional) Read-only PAT token. Uncomment the `repo_token` line below if:
+          # - you want to enable the Branch-Protection check on a *public* repository, or
+          # - you are installing Scorecards on a *private* repository
+          # To create the PAT, follow the steps in https://github.com/ossf/scorecard-action#authentication-with-pat.
+          # repo_token: ${{ secrets.SCORECARD_READ_TOKEN }}
+
+          # Publish the results for public repositories to enable scorecard badges. For more details, see
+          # https://github.com/ossf/scorecard-action#publishing-results.
+          # For private repositories, `publish_results` will automatically be set to `false`, regardless
+          # of the value entered here.
+          publish_results: true
+
+      # Upload the results as artifacts (optional). Commenting out will disable uploads of run results in SARIF
+      # format to the repository Actions tab.
+      - name: "Upload artifact"
+        uses: actions/upload-artifact@6673cd052c4cd6fcf4b4e6e60ea986c889389535 # v3.0.0
+        with:
+          name: SARIF file
+          path: results.sarif
+          retention-days: 5
+
+      # Upload the results to GitHub's code scanning dashboard.
+      - name: "Upload to code-scanning"
+        uses: github/codeql-action/upload-sarif@5f532563584d71fdef14ee64d17bafb34f751ce5 # v1.0.26
+        with:
+          sarif_file: results.sarif

--- a/README.adoc
+++ b/README.adoc
@@ -10,6 +10,7 @@ Jonas Pammer <opensource@jonaspammer.at>;
 https://github.com/JonasPammer/cookiecutter-pypackage-test/actions/workflows/ci.yml[image:https://github.com/JonasPammer/cookiecutter-pypackage-test/actions/workflows/ci.yml/badge.svg[CI Status]]
 image:https://img.shields.io/pypi/pyversions/test_application.svg[Python Versions]
 
+https://api.securityscorecards.dev/projects/github.com/JonasPammer/cookiecutter-pypackage-test[image:https://api.securityscorecards.dev/projects/github.com/JonasPammer/cookiecutter-pypackage-test/badge[OpenSSF Scorecard]]
 
 A Python Package to do random stuff.
 

--- a/README.md
+++ b/README.md
@@ -3,6 +3,9 @@ Status](https://github.com/JonasPammer/cookiecutter-pypackage-test/actions/workf
 ![Python
 Versions](https://img.shields.io/pypi/pyversions/test_application.svg)
 
+[![OpenSSF
+Scorecard](https://api.securityscorecards.dev/projects/github.com/JonasPammer/cookiecutter-pypackage-test/badge)](https://api.securityscorecards.dev/projects/github.com/JonasPammer/cookiecutter-pypackage-test)
+
 A Python Package to do random stuff.
 
 # Features

--- a/README.orig.adoc
+++ b/README.orig.adoc
@@ -18,6 +18,7 @@ endif::[]
 https://github.com/JonasPammer/cookiecutter-pypackage-test/actions/workflows/ci.yml[image:https://github.com/JonasPammer/cookiecutter-pypackage-test/actions/workflows/ci.yml/badge.svg[CI Status]]
 image:https://img.shields.io/pypi/pyversions/test_application.svg[Python Versions]
 
+https://api.securityscorecards.dev/projects/github.com/JonasPammer/cookiecutter-pypackage-test[image:https://api.securityscorecards.dev/projects/github.com/JonasPammer/cookiecutter-pypackage-test/badge[OpenSSF Scorecard]]
 
 A Python Package to do random stuff.
 


### PR DESCRIPTION
as seen in https://github.com/ossf/scorecard-action/tree/1a2e1e9d70515b7cc10823d694d234eef1e4a657

Proof of Concept for https://github.com/JonasPammer/cookiecutter-pypackage/issues/32

if ok, do not merge but implement in [upstream](https://github.com/JonasPammer/cookiecutter-pypackage/tree/32-ci-add-ossf-scorecard-action-and-badge)


## **Required Checklist**

- [x] Documentation has been altered or extended appropriately
- [x] This pull request and its commits address only a single concern
- [x] I am a nice guy <!-- the 'too long; did not read;' of the CODE_OF_CONDUCT.md -->

## Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)

## _Optional_ Checklist

- [x] pre-commit was installed in local development environment (if not, a GitHub workflow will run pre-commit once you create the request)

- [x] my commits are small, single-purpose, detailed and maybe even follow the [conventional commit specification](https://github.com/JonasPammer/JonasPammer/blob/master/demystifying/conventional_commits.adoc) for extra convenience of the reviewer
